### PR TITLE
Patch rerun

### DIFF
--- a/Initialization/02. Housing/02. Pull Census Data - PUMS & Data Profiles.ipynb
+++ b/Initialization/02. Housing/02. Pull Census Data - PUMS & Data Profiles.ipynb
@@ -396,7 +396,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "os.mkdir('../../SupportingDocs/Housing/01_Raw')"
+    "dir_raw = '../../SupportingDocs/Housing/01_Raw'\n",
+    "\n",
+    "os.makedirs(dir_raw, exist_ok=True)"
    ]
   },
   {
@@ -413,13 +415,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_PUMS_vars.to_csv('../../SupportingDocs/Housing/01_Raw/PUMS_all_variables.csv',index=False)\n",
+    "df_PUMS_vars.to_csv(f'{dir_raw}/PUMS_all_variables.csv',index=False)\n",
     "\n",
-    "df_PUMS_housing_values.to_csv('../../SupportingDocs/Housing/01_Raw/PUMS_housing_variable_mappings.csv',index=False)\n",
-    "df_PUMS_housing_raw.to_csv('../../SupportingDocs/Housing/01_Raw/PUMS_housing_data.csv',index=False)\n",
+    "df_PUMS_housing_values.to_csv(f'{dir_raw}/PUMS_housing_variable_mappings.csv',index=False)\n",
+    "df_PUMS_housing_raw.to_csv(f'{dir_raw}/PUMS_housing_data.csv',index=False)\n",
     "\n",
-    "df_PUMS_person_values.to_csv('../../SupportingDocs/Housing/01_Raw/PUMS_person_variable_mappings.csv',index=False)\n",
-    "df_PUMS_person_raw.to_csv('../../SupportingDocs/Housing/01_Raw/PUMS_person_data.csv',index=False)"
+    "df_PUMS_person_values.to_csv(f'{dir_raw}/PUMS_person_variable_mappings.csv',index=False)\n",
+    "df_PUMS_person_raw.to_csv(f'{dir_raw}/PUMS_person_data.csv',index=False)"
    ]
   },
   {
@@ -436,9 +438,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_DP_vars.to_csv('../../SupportingDocs/Housing/01_Raw/DP_all_variables.csv',index=False)\n",
-    "df_DP_housing_values.to_csv('../../SupportingDocs/Housing/01_Raw/DP_housing_variable_mappings.csv',index=False)\n",
-    "df_DP_person_raw.to_csv('../../SupportingDocs/Housing/01_Raw/DP_housing_data.csv',index=False)"
+    "df_DP_vars.to_csv(f'{dir_raw}/DP_all_variables.csv',index=False)\n",
+    "df_DP_housing_values.to_csv(f'{dir_raw}/DP_housing_variable_mappings.csv',index=False)\n",
+    "df_DP_person_raw.to_csv(f'{dir_raw}/DP_housing_data.csv',index=False)"
    ]
   },
   {

--- a/Initialization/02. Housing/03. Wrangle Census Data.ipynb
+++ b/Initialization/02. Housing/03. Wrangle Census Data.ipynb
@@ -42,7 +42,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -150,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -191,7 +191,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -309,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -354,7 +354,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -392,7 +392,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -443,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -476,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -531,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -564,7 +564,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -596,7 +596,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -608,12 +608,14 @@
    },
    "outputs": [],
    "source": [
-    "os.mkdir('../../SupportingDocs/Housing/02_Wrangled')"
+    "dir_wrangled = '../../SupportingDocs/Housing/02_Wrangled'\n",
+    "\n",
+    "os.makedirs(dir_wrangled, exist_ok=True)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
@@ -625,12 +627,12 @@
    },
    "outputs": [],
    "source": [
-    "df_filtered.to_csv('../../SupportingDocs/Housing/02_Wrangled/PUMS_housing_1to1.csv',index=False)"
+    "df_filtered.to_csv(f'{dir_wrangled}/PUMS_housing_1to1.csv',index=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 0,
+   "execution_count": null,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},

--- a/Initialization/03. Table Setup/04. Births Table - Grandparent Generation.py
+++ b/Initialization/03. Table Setup/04. Births Table - Grandparent Generation.py
@@ -381,7 +381,7 @@ spdf = spdf.withColumn('dob', sp_assign_dob(F.col('age')))
 
 # Prep spdf for name assignment by giving unique row_numbers to match on partitioned intentionally by characteristic.
 spdf = spdf.withColumn('yob', F.col('dob').substr(1,4))\
-           .withColumn('yob_match', F.when(F.col('yob') < 1880, F.lit(1880)).otherwise(F.col('yob')))\
+           .withColumn('yob_match', F.when(F.col('yob') < 1895, F.lit(1895)).otherwise(F.col('yob')))\
            .withColumn('fname_rownum', F.row_number().over(Window.partitionBy(['sex_at_birth','race','yob']).orderBy(F.rand(1))))\
            .withColumn('lname_rownum', F.row_number().over(Window.partitionBy(['race']).orderBy(F.rand(2))))
 

--- a/Initialization/03. Table Setup/08. Initialize Tables.py
+++ b/Initialization/03. Table Setup/08. Initialize Tables.py
@@ -441,15 +441,3 @@ logState(path=synthetic_gold_stateManagement, upcoming_year=1890)
 
 
 
-# COMMAND ----------
-
-
-
-# COMMAND ----------
-
-spdf = spark.read.format('delta').load(f'{synthetic_gold_data_path}/SyntheticGold/Delta')
-spdf.display()
-
-# COMMAND ----------
-
-

--- a/Initialization/03. Table Setup/README.md
+++ b/Initialization/03. Table Setup/README.md
@@ -9,7 +9,7 @@ When we start the simulation, we retrace all individuals to 1890 and run the sim
 
 2. *Databricks* - Navigate to *04. Births Table - Grandparent Generation.py*.  Run script and wait for completion.
 
-3. *Databricks* - Navigate to *05. Population Table - Grandparent Generation.py*.  Run script and wait for completion.
+3. *Databricks* - Navigate to *05. Population Table - Grandparent Generation.py*.  **FOLLOW INSTRUCTIONS IN BEGINNING MARKDOWN OF SCRIPT**. THEN run script and wait for completion.
 
 4. *Databricks* - You can run 06. PhoneLookup Table.py* and *07. AdjectiveLookup.py* at the same time.  Please wait until all scripts have completed successfully before proceeding.
 


### PR DESCRIPTION
Currently rerunning for Nebraska.  Here are some things that I learned/tweaked:

- You have to meticulously follow the instructions in the README.md files.  Knowing the project well and recently writing them, I thought I could get by without doing that and had to retrace steps when I got funky behavior.  Turns out I just wasn't following the instructions I made.
- There was a population bug in the births for grandparents generation where the YOB field should have been set to 1895 for old people, but was instead adjusted to 1980.  When a join took place, all old people were excluded from the output.  Good to fix that.
- When rerunning old scripts, you get an error with `os.mkdir()`, so use `os.makedirs(exist_ok=True)`.  Fixes it.
- Small documentation tweaks.